### PR TITLE
The auto-generated trial license can override an existing license #98

### DIFF
--- a/application-licensing-licensor/application-licensing-licensor-api/pom.xml
+++ b/application-licensing-licensor/application-licensing-licensor-api/pom.xml
@@ -37,7 +37,7 @@
     <xwiki.extension.category>API</xwiki.extension.category>
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
     <checkstyle.suppressions.location>${basedir}/src/main/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-    <xwiki.jacoco.instructionRatio>0.41</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.43</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/GetTrialLicenseListener.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/GetTrialLicenseListener.java
@@ -30,12 +30,10 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.extension.Extension;
 import org.xwiki.extension.ExtensionDependency;
 import org.xwiki.extension.ExtensionId;
 import org.xwiki.extension.InstalledExtension;
 import org.xwiki.extension.ResolveException;
-import org.xwiki.extension.repository.ExtensionRepositoryManager;
 import org.xwiki.extension.repository.InstalledExtensionRepository;
 import org.xwiki.job.event.JobFinishedEvent;
 import org.xwiki.observation.EventListener;
@@ -62,9 +60,6 @@ public class GetTrialLicenseListener implements EventListener
 
     @Inject
     private InstalledExtensionRepository installedExtensionRepository;
-
-    @Inject
-    private ExtensionRepositoryManager repositoryManager;
 
     @Inject
     private Logger logger;
@@ -111,8 +106,8 @@ public class GetTrialLicenseListener implements EventListener
                 Collection<ExtensionDependency> dependencies = installedExtension.getDependencies();
                 for (ExtensionDependency dependency : dependencies) {
                     try {
-                        Extension extension = repositoryManager.resolve(dependency);
-                        tryGenerateTrialLicenseRecursive(extension.getId());
+                        InstalledExtension installedDependency = installedExtensionRepository.resolve(dependency);
+                        tryGenerateTrialLicenseRecursive(installedDependency.getId());
                     } catch (ResolveException e) {
                         logger.warn("Failed to check [{}] for a license. Root cause is [{}]", dependency.getId(),
                             ExceptionUtils.getRootCauseMessage(e));

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/GetTrialLicenseListener.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/GetTrialLicenseListener.java
@@ -67,7 +67,7 @@ public class GetTrialLicenseListener implements EventListener
     public void onEvent(Event event, Object source, Object data)
     {
         List<ExtensionId> extensions = ((JobFinishedEvent) event).getRequest().getProperty("extensions");
-        // Retrieve license updates to be sure that it doesn't override an existing license.
+        // Retrieve license updates to be sure that we don't override an existing license.
         trialLicenseGenerator.updateLicenses();
 
         for (ExtensionId extensionId : extensions) {

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
@@ -132,7 +132,8 @@ public class TrialLicenseGenerator
      */
     public Boolean canGenerateTrialLicense(ExtensionId extensionId)
     {
-        return isOwnerDataComplete() && isMandatoryLicensedExtension(extensionId) && !isLicensed(extensionId);
+        return isOwnerDataComplete() && isMandatoryLicensedExtension(extensionId)
+            && License.UNLICENSED.equals(licensorProvider.get().getLicense(extensionId));
     }
 
     /**
@@ -168,7 +169,7 @@ public class TrialLicenseGenerator
      * Retrieve license updates from the XWiki Store.
      */
     @SuppressWarnings("unchecked")
-    private void updateLicenses()
+    public void updateLicenses()
     {
         try {
             URL licensesUpdateURL = getLicensesUpdateURL();
@@ -248,19 +249,5 @@ public class TrialLicenseGenerator
         return !(StringUtils.isEmpty(licensingConfig.getLicensingOwnerLastName())
             || StringUtils.isEmpty(licensingConfig.getLicensingOwnerFirstName())
             || StringUtils.isEmpty(licensingConfig.getLicensingOwnerEmail()));
-    }
-
-    /**
-     * Check if the given paid extension has already a license. We need to retrieve license updates from the XWiki Store
-     * before, in case there is already an active license of the extension.
-     *
-     * @param extensionId the extension to be checked
-     * @return true if the extension is licensed, false otherwise.
-     */
-    private Boolean isLicensed(ExtensionId extensionId)
-    {
-        updateLicenses();
-
-        return licensorProvider.get().getLicense(extensionId) != null;
     }
 }

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
@@ -132,8 +132,7 @@ public class TrialLicenseGenerator
      */
     public Boolean canGenerateTrialLicense(ExtensionId extensionId)
     {
-        return isOwnerDataComplete() && isMandatoryLicensedExtension(extensionId)
-            && licensorProvider.get().getLicense(extensionId) == null;
+        return isOwnerDataComplete() && isMandatoryLicensedExtension(extensionId) && !isLicensed(extensionId);
     }
 
     /**
@@ -249,5 +248,19 @@ public class TrialLicenseGenerator
         return !(StringUtils.isEmpty(licensingConfig.getLicensingOwnerLastName())
             || StringUtils.isEmpty(licensingConfig.getLicensingOwnerFirstName())
             || StringUtils.isEmpty(licensingConfig.getLicensingOwnerEmail()));
+    }
+
+    /**
+     * Check if the given paid extension has already a license. We need to retrieve license updates from the XWiki Store
+     * before, in case there is already an active license of the extension.
+     *
+     * @param extensionId the extension to be checked
+     * @return true if the extension is licensed, false otherwise.
+     */
+    private Boolean isLicensed(ExtensionId extensionId)
+    {
+        updateLicenses();
+
+        return licensorProvider.get().getLicense(extensionId) != null;
     }
 }

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
@@ -219,7 +219,7 @@ public class TrialLicenseGenerator
             builder.addParameter(FEATURE_ID, paidExtensionId.getId());
 
             License license = licensorProvider.get().getLicense(paidExtensionId);
-            if (license != null) {
+            if (license != null && !License.UNLICENSED.equals(license)) {
                 builder.addParameter(String.format("expirationDate:%s", paidExtensionId.getId()),
                     Long.toString(license.getExpirationDate()));
             }

--- a/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/GetTrialLicenseListenerTest.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/GetTrialLicenseListenerTest.java
@@ -32,11 +32,9 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.xwiki.extension.Extension;
 import org.xwiki.extension.ExtensionDependency;
 import org.xwiki.extension.ExtensionId;
 import org.xwiki.extension.InstalledExtension;
-import org.xwiki.extension.repository.ExtensionRepositoryManager;
 import org.xwiki.extension.repository.InstalledExtensionRepository;
 import org.xwiki.extension.repository.internal.installed.DefaultInstalledExtension;
 import org.xwiki.extension.version.Version;
@@ -67,8 +65,6 @@ public class GetTrialLicenseListenerTest
 
     InstalledExtensionRepository installedExtensionRepository;
 
-    ExtensionRepositoryManager repositoryManager;
-
     @Before
     public void configure() throws Exception
     {
@@ -76,7 +72,6 @@ public class GetTrialLicenseListenerTest
         this.extension = mock(DefaultInstalledExtension.class);
         this.extensionId = new ExtensionId("application-test", "1.0");
         this.trialLicenseGenerator = this.mocker.getInstance(TrialLicenseGenerator.class);
-        this.repositoryManager = this.mocker.getInstance(ExtensionRepositoryManager.class);
 
         Request request = mock(Request.class);
         List<ExtensionId> extensions = Arrays.asList(this.extensionId);
@@ -89,14 +84,14 @@ public class GetTrialLicenseListenerTest
 
         when(this.installedExtensionRepository.getInstalledExtension(this.extensionId)).thenReturn(installedExtension);
 
-        Extension dependencyExtension = mock(Extension.class);
+        InstalledExtension installedDependency = mock(InstalledExtension.class);
         ExtensionDependency dependency = mock(ExtensionDependency.class);
         Collection<ExtensionDependency> dependencies = Arrays.asList(dependency);
         this.dependencyId = new ExtensionId("application-dependency", mock(Version.class));
 
         when(installedExtension.getDependencies()).thenReturn(dependencies);
-        when(this.repositoryManager.resolve(dependency)).thenReturn(dependencyExtension);
-        when(dependencyExtension.getId()).thenReturn(dependencyId);
+        when(this.installedExtensionRepository.resolve(dependency)).thenReturn(installedDependency);
+        when(installedDependency.getId()).thenReturn(dependencyId);
     }
 
     @Test
@@ -145,14 +140,14 @@ public class GetTrialLicenseListenerTest
         when(this.installedExtensionRepository.getInstalledExtension(this.dependencyId))
             .thenReturn(installedDependencyExtension);
 
-        Extension transitiveExtension = mock(Extension.class);
+        InstalledExtension installedTransitiveDependency = mock(InstalledExtension.class);
         ExtensionDependency transitiveDependency = mock(ExtensionDependency.class);
         Collection<ExtensionDependency> transitiveDependencies = Arrays.asList(transitiveDependency);
         ExtensionId transitiveDependencyId = new ExtensionId("application-dependency", mock(Version.class));
 
         when(installedDependencyExtension.getDependencies()).thenReturn(transitiveDependencies);
-        when(this.repositoryManager.resolve(transitiveDependency)).thenReturn(transitiveExtension);
-        when(transitiveExtension.getId()).thenReturn(transitiveDependencyId);
+        when(this.installedExtensionRepository.resolve(transitiveDependency)).thenReturn(installedTransitiveDependency);
+        when(installedTransitiveDependency.getId()).thenReturn(transitiveDependencyId);
 
         when(this.trialLicenseGenerator.canGenerateTrialLicense(transitiveDependencyId)).thenReturn(true);
 

--- a/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/TrialLicenseGeneratorTest.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/TrialLicenseGeneratorTest.java
@@ -205,7 +205,7 @@ public class TrialLicenseGeneratorTest
     @Test
     public void canGenerateTrialLicense() throws Exception
     {
-        when(this.licensor.getLicense(this.extension1)).thenReturn(null);
+        when(this.licensor.getLicense(this.extension1)).thenReturn(License.UNLICENSED);
 
         this.mocker.getComponentUnderTest().canGenerateTrialLicense(this.extension1);
 


### PR DESCRIPTION
Trial license is generated for the paid apps dependencies which should be covered by the parent license. #97
* try to generate a trial license only after the extension is fully installed; this will assure that all the present licenses are validated and there is no trial license generated for the paid apps dependencies, since they would not be seen as mandatory paid apps
* update licenses for the instance before checking if a trial license is needed