### PR TITLE
Wiki creation job freezes at 75% on an instance with multiple subwikis and pro applications installed #115

### DIFF
--- a/application-licensing-licensor/application-licensing-licensor-api/pom.xml
+++ b/application-licensing-licensor/application-licensing-licensor-api/pom.xml
@@ -37,7 +37,7 @@
     <xwiki.extension.category>API</xwiki.extension.category>
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
     <checkstyle.suppressions.location>${basedir}/src/main/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-    <xwiki.jacoco.instructionRatio>0.43</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.48</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/LicensedExtensionManager.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/LicensedExtensionManager.java
@@ -61,11 +61,13 @@ public interface LicensedExtensionManager
      * the license of other installed extensions (there aren't any other licensed extensions that depend on them).
      *
      * @return licensed extensions that are not dependencies of other licensed extensions
+     * @since 1.17
      */
     Collection<ExtensionId> getMandatoryLicensedExtensions();
 
     /**
      * Invalidate the cached list of mandatory licensed extensions.
+     * @since 1.21.1
      */
     void invalidateMandatoryLicensedExtensionsCache();
 }

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/LicensedExtensionManager.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/LicensedExtensionManager.java
@@ -63,4 +63,9 @@ public interface LicensedExtensionManager
      * @return licensed extensions that are not dependencies of other licensed extensions
      */
     Collection<ExtensionId> getMandatoryLicensedExtensions();
+
+    /**
+     * Invalidate the cached list of mandatory licensed extensions.
+     */
+    void invalidateMandatoryLicensedExtensionsCache();
 }

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManager.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManager.java
@@ -123,18 +123,21 @@ public class DefaultLicensedExtensionManager implements LicensedExtensionManager
     @Override
     public Set<ExtensionId> getMandatoryLicensedExtensions()
     {
-        Set<ExtensionId> mandatoryLicensedExtensions = computeMandatoryLicensedExtensions();
-        this.cachedMandatoryLicensedExtensions = mandatoryLicensedExtensions;
-        return mandatoryLicensedExtensions;
+        Set<ExtensionId> mandatoryLicensedExtensions = this.cachedMandatoryLicensedExtensions;
+        if (mandatoryLicensedExtensions == null) {
+            mandatoryLicensedExtensions = computeMandatoryLicensedExtensions();
+            this.cachedMandatoryLicensedExtensions = mandatoryLicensedExtensions;
+        }
+        return Collections.unmodifiableSet(mandatoryLicensedExtensions);
     }
 
     private synchronized Set<ExtensionId> computeMandatoryLicensedExtensions()
     {
-        if (this.cachedMandatoryLicensedExtensions != null) {
-            return this.cachedMandatoryLicensedExtensions;
+        Set<ExtensionId> mandatoryLicensedExtensions = this.cachedMandatoryLicensedExtensions;
+        if (mandatoryLicensedExtensions != null) {
+            return mandatoryLicensedExtensions;
         }
 
-        Set<ExtensionId> mandatoryLicensedExtensions = new HashSet<ExtensionId>();
         Collection<ExtensionId> allLicensedExtensions = getLicensedExtensions();
         // Extensions for which it was verified if the dependencies contain licensed extensions.
         Set<ExtensionId> verifiedExtensions = new HashSet<ExtensionId>();
@@ -172,7 +175,7 @@ public class DefaultLicensedExtensionManager implements LicensedExtensionManager
             ExtensionId dependencyId = installedDependency.getId();
             mandatoryLicensedExtensions.remove(dependencyId);
 
-            if (verifiedExtensions.contains(installedDependency.getId())) {
+            if (verifiedExtensions.contains(dependencyId)) {
                 continue;
             }
             verifiedExtensions.add(dependencyId);

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManager.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManager.java
@@ -123,9 +123,9 @@ public class DefaultLicensedExtensionManager implements LicensedExtensionManager
     @Override
     public Set<ExtensionId> getMandatoryLicensedExtensions()
     {
-        Set<ExtensionId> cache = computeMandatoryLicensedExtensions();
-        this.cachedMandatoryLicensedExtensions = cache;
-        return cache;
+        Set<ExtensionId> mandatoryLicensedExtensions = computeMandatoryLicensedExtensions();
+        this.cachedMandatoryLicensedExtensions = mandatoryLicensedExtensions;
+        return mandatoryLicensedExtensions;
     }
 
     private synchronized Set<ExtensionId> computeMandatoryLicensedExtensions()

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/GetTrialLicenseListener.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/GetTrialLicenseListener.java
@@ -80,6 +80,8 @@ public class GetTrialLicenseListener implements EventListener
     public void onEvent(Event event, Object source, Object data)
     {
         List<ExtensionId> extensions = ((JobFinishedEvent) event).getRequest().getProperty("extensions");
+
+        licensedExtensionManager.invalidateMandatoryLicensedExtensionsCache();
         // Retrieve license updates to be sure that we don't override an existing license.
         trialLicenseGenerator.updateLicenses();
 
@@ -89,8 +91,6 @@ public class GetTrialLicenseListener implements EventListener
             dependencyPath.push(extensionId);
             tryGenerateTrialLicenseRecursive(dependencyPath, installedExtension.getNamespaces());
         }
-
-        licensedExtensionManager.invalidateMandatoryLicensedExtensionsCache();
     }
 
     /**

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
@@ -132,8 +132,8 @@ public class TrialLicenseGenerator
      */
     public Boolean canGenerateTrialLicense(ExtensionId extensionId)
     {
-        return isOwnerDataComplete() && isMandatoryLicensedExtension(extensionId)
-            && License.UNLICENSED.equals(licensorProvider.get().getLicense(extensionId));
+        return License.UNLICENSED.equals(licensorProvider.get().getLicense(extensionId)) && isOwnerDataComplete()
+            && isMandatoryLicensedExtension(extensionId);
     }
 
     /**
@@ -238,7 +238,7 @@ public class TrialLicenseGenerator
     private Boolean isMandatoryLicensedExtension(ExtensionId extensionId)
     {
         return licensedExtensionManager.getMandatoryLicensedExtensions().stream()
-            .filter(extension -> extension.getId().contentEquals(extensionId.getId())).findFirst().isPresent();
+            .anyMatch(mandatoryExtensionId -> mandatoryExtensionId.equals(extensionId));
     }
 
     /**

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/TrialLicenseGenerator.java
@@ -237,8 +237,7 @@ public class TrialLicenseGenerator
      */
     private Boolean isMandatoryLicensedExtension(ExtensionId extensionId)
     {
-        return licensedExtensionManager.getMandatoryLicensedExtensions().stream()
-            .anyMatch(mandatoryExtensionId -> mandatoryExtensionId.equals(extensionId));
+        return licensedExtensionManager.getMandatoryLicensedExtensions().contains(extensionId);
     }
 
     /**

--- a/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManagerTest.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManagerTest.java
@@ -19,8 +19,7 @@
  */
 package com.xwiki.licensing.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -34,72 +33,82 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xwiki.extension.ExtensionDependency;
 import org.xwiki.extension.ExtensionId;
 import org.xwiki.extension.InstalledExtension;
 import org.xwiki.extension.repository.InstalledExtensionRepository;
-import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
 
 /**
  * Unit tests for {@link DefaultLicensedExtensionManager}.
  * 
  * @version $Id$
  */
+@ComponentTest
 public class DefaultLicensedExtensionManagerTest
 {
-    @Rule
-    public MockitoComponentMockingRule<DefaultLicensedExtensionManager> mocker =
-        new MockitoComponentMockingRule<>(DefaultLicensedExtensionManager.class);
 
+    @InjectMockComponents
+    DefaultLicensedExtensionManager licensedExtensionManager;
+
+    @MockComponent
     InstalledExtensionRepository installedExtensionRepository;
 
-    Map<String, Collection<InstalledExtension>> licensorDependencies;
-
+    @MockComponent
     InstalledExtension licensorExtension;
 
+    @MockComponent
     InstalledExtension pollsExtension;
 
+    @MockComponent
     InstalledExtension flashV1Extension;
 
+    @MockComponent
     ExtensionDependency flashV1Dependency;
 
+    @MockComponent
     InstalledExtension flashV2Extension;
+
+    @MockComponent
+    ExtensionDependency flashV2Dependency;
+
+    @MockComponent
+    InstalledExtension freeExtension;
+
+    @MockComponent
+    ExtensionDependency freeExtensionDependency;
+
+    Map<String, Collection<InstalledExtension>> licensorDependencies;
 
     ExtensionId flashV2ExtensionId;
 
     List<String> pollsNamespaces;
 
-    @Before
-    public void configure() throws Exception
+    @BeforeEach
+    public void configure(MockitoComponentManager componentManager)
     {
-        this.installedExtensionRepository = this.mocker.getInstance(InstalledExtensionRepository.class);
-
         this.licensorDependencies = new HashMap<>();
-        this.licensorExtension = mock(InstalledExtension.class);
         when(this.installedExtensionRepository
             .getInstalledExtension(DefaultLicensedExtensionManager.LICENSOR_EXTENSION_ID, null))
                 .thenReturn(this.licensorExtension);
 
-        this.pollsExtension = mock(InstalledExtension.class);
         ExtensionId pollsExtensionId = new ExtensionId("application-xpoll", "1.0");
         when(this.pollsExtension.getId()).thenReturn(pollsExtensionId);
         this.pollsNamespaces = Arrays.asList("main");
         when(this.pollsExtension.getNamespaces()).thenReturn(this.pollsNamespaces);
 
-        this.flashV1Extension = mock(InstalledExtension.class);
         ExtensionId flashV1ExtensionId = new ExtensionId("application-flash", "1.1");
         when(this.flashV1Extension.getId()).thenReturn(flashV1ExtensionId);
-        this.flashV1Dependency = mock(ExtensionDependency.class);
         when(this.flashV1Dependency.getId()).thenReturn(flashV1ExtensionId.getId());
         when(this.flashV1Extension.getNamespaces()).thenReturn(this.pollsNamespaces);
 
-        this.flashV2Extension = mock(InstalledExtension.class);
         this.flashV2ExtensionId = new ExtensionId("application-flash", "2.1");
         when(this.flashV2Extension.getId()).thenReturn(this.flashV2ExtensionId);
-        ExtensionDependency flashV2Dependency = mock(ExtensionDependency.class);
         when(flashV2Dependency.getId()).thenReturn(this.flashV2ExtensionId.getId());
 
         when(this.installedExtensionRepository.getInstalledExtension(pollsExtensionId)).thenReturn(this.pollsExtension);
@@ -127,7 +136,7 @@ public class DefaultLicensedExtensionManagerTest
         Set<ExtensionId> expected = new HashSet<>();
         expected.add(this.pollsExtension.getId());
 
-        Set<ExtensionId> result = this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions();
+        Set<ExtensionId> result = this.licensedExtensionManager.getMandatoryLicensedExtensions();
 
         assertEquals(expected, result);
     }
@@ -142,6 +151,8 @@ public class DefaultLicensedExtensionManagerTest
 
         List<String> flashV2Namespaces = Arrays.asList("wiki2");
         when(this.flashV2Extension.getNamespaces()).thenReturn(flashV2Namespaces);
+        when(this.installedExtensionRepository.getInstalledExtension(this.flashV2ExtensionId))
+            .thenReturn(this.flashV2Extension);
         when(this.installedExtensionRepository.getInstalledExtension(this.flashV2ExtensionId.getId(),
             flashV2Namespaces.get(0))).thenReturn(this.flashV2Extension);
 
@@ -149,7 +160,7 @@ public class DefaultLicensedExtensionManagerTest
         expected.add(this.pollsExtension.getId());
         expected.add(this.flashV2ExtensionId);
 
-        Set<ExtensionId> result = this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions();
+        Set<ExtensionId> result = this.licensedExtensionManager.getMandatoryLicensedExtensions();
 
         assertEquals(expected, result);
     }
@@ -161,10 +172,8 @@ public class DefaultLicensedExtensionManagerTest
         when(this.installedExtensionRepository.getBackwardDependencies(this.licensorExtension.getId()))
             .thenReturn(this.licensorDependencies);
 
-        InstalledExtension freeExtension = mock(InstalledExtension.class);
         ExtensionId freeExtensionId = new ExtensionId("application-free", "1.1");
         when(freeExtension.getId()).thenReturn(freeExtensionId);
-        ExtensionDependency freeExtensionDependency = mock(ExtensionDependency.class);
         when(freeExtensionDependency.getId()).thenReturn(freeExtensionId.getId());
         when(this.installedExtensionRepository.getInstalledExtension(freeExtensionDependency.getId(),
             this.pollsNamespaces.get(0))).thenReturn(freeExtension);
@@ -175,7 +184,7 @@ public class DefaultLicensedExtensionManagerTest
         Set<ExtensionId> expected = new HashSet<>();
         expected.add(this.pollsExtension.getId());
 
-        Set<ExtensionId> result = this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions();
+        Set<ExtensionId> result = this.licensedExtensionManager.getMandatoryLicensedExtensions();
 
         assertEquals(expected, result);
     }
@@ -191,8 +200,8 @@ public class DefaultLicensedExtensionManagerTest
         Set<ExtensionId> expected = new HashSet<>();
         expected.add(this.pollsExtension.getId());
 
-        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
-        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
+        assertEquals(expected, this.licensedExtensionManager.getMandatoryLicensedExtensions());
+        assertEquals(expected, this.licensedExtensionManager.getMandatoryLicensedExtensions());
 
         verify(this.installedExtensionRepository, times(1))
             .getInstalledExtension(DefaultLicensedExtensionManager.LICENSOR_EXTENSION_ID, null);
@@ -209,9 +218,9 @@ public class DefaultLicensedExtensionManagerTest
         Set<ExtensionId> expected = new HashSet<>();
         expected.add(this.pollsExtension.getId());
 
-        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
-        this.mocker.getComponentUnderTest().invalidateMandatoryLicensedExtensionsCache();
-        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
+        assertEquals(expected, this.licensedExtensionManager.getMandatoryLicensedExtensions());
+        this.licensedExtensionManager.invalidateMandatoryLicensedExtensionsCache();
+        assertEquals(expected, this.licensedExtensionManager.getMandatoryLicensedExtensions());
 
         verify(this.installedExtensionRepository, times(2))
             .getInstalledExtension(DefaultLicensedExtensionManager.LICENSOR_EXTENSION_ID, null);

--- a/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManagerTest.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/DefaultLicensedExtensionManagerTest.java
@@ -1,0 +1,220 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.licensing.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.xwiki.extension.ExtensionDependency;
+import org.xwiki.extension.ExtensionId;
+import org.xwiki.extension.InstalledExtension;
+import org.xwiki.extension.repository.InstalledExtensionRepository;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+
+/**
+ * Unit tests for {@link DefaultLicensedExtensionManager}.
+ * 
+ * @version $Id$
+ */
+public class DefaultLicensedExtensionManagerTest
+{
+    @Rule
+    public MockitoComponentMockingRule<DefaultLicensedExtensionManager> mocker =
+        new MockitoComponentMockingRule<>(DefaultLicensedExtensionManager.class);
+
+    InstalledExtensionRepository installedExtensionRepository;
+
+    Map<String, Collection<InstalledExtension>> licensorDependencies;
+
+    InstalledExtension licensorExtension;
+
+    InstalledExtension pollsExtension;
+
+    InstalledExtension flashV1Extension;
+
+    ExtensionDependency flashV1Dependency;
+
+    InstalledExtension flashV2Extension;
+
+    ExtensionId flashV2ExtensionId;
+
+    List<String> pollsNamespaces;
+
+    @Before
+    public void configure() throws Exception
+    {
+        this.installedExtensionRepository = this.mocker.getInstance(InstalledExtensionRepository.class);
+
+        this.licensorDependencies = new HashMap<>();
+        this.licensorExtension = mock(InstalledExtension.class);
+        when(this.installedExtensionRepository
+            .getInstalledExtension(DefaultLicensedExtensionManager.LICENSOR_EXTENSION_ID, null))
+                .thenReturn(this.licensorExtension);
+
+        this.pollsExtension = mock(InstalledExtension.class);
+        ExtensionId pollsExtensionId = new ExtensionId("application-xpoll", "1.0");
+        when(this.pollsExtension.getId()).thenReturn(pollsExtensionId);
+        this.pollsNamespaces = Arrays.asList("main");
+        when(this.pollsExtension.getNamespaces()).thenReturn(this.pollsNamespaces);
+
+        this.flashV1Extension = mock(InstalledExtension.class);
+        ExtensionId flashV1ExtensionId = new ExtensionId("application-flash", "1.1");
+        when(this.flashV1Extension.getId()).thenReturn(flashV1ExtensionId);
+        this.flashV1Dependency = mock(ExtensionDependency.class);
+        when(this.flashV1Dependency.getId()).thenReturn(flashV1ExtensionId.getId());
+        when(this.flashV1Extension.getNamespaces()).thenReturn(this.pollsNamespaces);
+
+        this.flashV2Extension = mock(InstalledExtension.class);
+        this.flashV2ExtensionId = new ExtensionId("application-flash", "2.1");
+        when(this.flashV2Extension.getId()).thenReturn(this.flashV2ExtensionId);
+        ExtensionDependency flashV2Dependency = mock(ExtensionDependency.class);
+        when(flashV2Dependency.getId()).thenReturn(this.flashV2ExtensionId.getId());
+
+        when(this.installedExtensionRepository.getInstalledExtension(pollsExtensionId)).thenReturn(this.pollsExtension);
+        when(this.installedExtensionRepository.getInstalledExtension(pollsExtensionId.getId(),
+            this.pollsNamespaces.get(0))).thenReturn(this.pollsExtension);
+
+        Collection<ExtensionDependency> pollsDependencies = Arrays.asList(this.flashV1Dependency);
+        when(this.pollsExtension.getDependencies()).thenReturn(pollsDependencies);
+
+        when(this.installedExtensionRepository.getInstalledExtension(this.flashV1Dependency.getId(),
+            this.pollsNamespaces.get(0))).thenReturn(this.flashV1Extension);
+        when(this.installedExtensionRepository.getInstalledExtension(this.flashV1Extension.getId()))
+            .thenReturn(this.flashV1Extension);
+
+    }
+
+    @Test
+    public void getMandatoryLicensedExtensions() throws Exception
+    {
+
+        this.licensorDependencies.put(null, Arrays.asList(this.pollsExtension, this.flashV1Extension));
+        when(this.installedExtensionRepository.getBackwardDependencies(this.licensorExtension.getId()))
+            .thenReturn(this.licensorDependencies);
+
+        Set<ExtensionId> expected = new HashSet<>();
+        expected.add(this.pollsExtension.getId());
+
+        Set<ExtensionId> result = this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getMandatoryLicensedExtensionsWithDifferentVersionOnNamespaces() throws Exception
+    {
+        this.licensorDependencies.put(null,
+            Arrays.asList(this.pollsExtension, this.flashV1Extension, this.flashV2Extension));
+        when(this.installedExtensionRepository.getBackwardDependencies(this.licensorExtension.getId()))
+            .thenReturn(this.licensorDependencies);
+
+        List<String> flashV2Namespaces = Arrays.asList("wiki2");
+        when(this.flashV2Extension.getNamespaces()).thenReturn(flashV2Namespaces);
+        when(this.installedExtensionRepository.getInstalledExtension(this.flashV2ExtensionId.getId(),
+            flashV2Namespaces.get(0))).thenReturn(this.flashV2Extension);
+
+        Set<ExtensionId> expected = new HashSet<>();
+        expected.add(this.pollsExtension.getId());
+        expected.add(this.flashV2ExtensionId);
+
+        Set<ExtensionId> result = this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getMandatoryLicensedExtensionsWithTransitivePaidDependency() throws Exception
+    {
+        this.licensorDependencies.put(null, Arrays.asList(this.pollsExtension, this.flashV1Extension));
+        when(this.installedExtensionRepository.getBackwardDependencies(this.licensorExtension.getId()))
+            .thenReturn(this.licensorDependencies);
+
+        InstalledExtension freeExtension = mock(InstalledExtension.class);
+        ExtensionId freeExtensionId = new ExtensionId("application-free", "1.1");
+        when(freeExtension.getId()).thenReturn(freeExtensionId);
+        ExtensionDependency freeExtensionDependency = mock(ExtensionDependency.class);
+        when(freeExtensionDependency.getId()).thenReturn(freeExtensionId.getId());
+        when(this.installedExtensionRepository.getInstalledExtension(freeExtensionDependency.getId(),
+            this.pollsNamespaces.get(0))).thenReturn(freeExtension);
+
+        when(this.pollsExtension.getDependencies()).thenReturn(Arrays.asList(freeExtensionDependency));
+        when(freeExtension.getDependencies()).thenReturn(Arrays.asList(this.flashV1Dependency));
+
+        Set<ExtensionId> expected = new HashSet<>();
+        expected.add(this.pollsExtension.getId());
+
+        Set<ExtensionId> result = this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getMandatoryLicensedExtensionsIsCached() throws Exception
+    {
+        this.licensorDependencies.put(null, Arrays.asList(this.pollsExtension));
+        when(this.installedExtensionRepository.getBackwardDependencies(this.licensorExtension.getId()))
+            .thenReturn(this.licensorDependencies);
+        when(this.pollsExtension.getDependencies()).thenReturn(Collections.<ExtensionDependency>emptyList());
+
+        Set<ExtensionId> expected = new HashSet<>();
+        expected.add(this.pollsExtension.getId());
+
+        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
+        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
+
+        verify(this.installedExtensionRepository, times(1))
+            .getInstalledExtension(DefaultLicensedExtensionManager.LICENSOR_EXTENSION_ID, null);
+    }
+
+    @Test
+    public void invalidateMandatoryLicensedExtensionsCache() throws Exception
+    {
+        this.licensorDependencies.put(null, Arrays.asList(this.pollsExtension));
+        when(this.installedExtensionRepository.getBackwardDependencies(this.licensorExtension.getId()))
+            .thenReturn(this.licensorDependencies);
+        when(this.pollsExtension.getDependencies()).thenReturn(Collections.<ExtensionDependency>emptyList());
+
+        Set<ExtensionId> expected = new HashSet<>();
+        expected.add(this.pollsExtension.getId());
+
+        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
+        this.mocker.getComponentUnderTest().invalidateMandatoryLicensedExtensionsCache();
+        assertEquals(expected, this.mocker.getComponentUnderTest().getMandatoryLicensedExtensions());
+
+        verify(this.installedExtensionRepository, times(2))
+            .getInstalledExtension(DefaultLicensedExtensionManager.LICENSOR_EXTENSION_ID, null);
+    }
+
+}


### PR DESCRIPTION
* refactor GetTrialLicenseListener#tryGenerateTrialLicenseRecursive to remember the dependencied there were already verified
* consider the namespace of the verified extensions
* modified TrialLicenseGenerator#canGenerateTrialLicense to have the least costly conditions first
* refactor DefaultLicensedExtensionManager#getMandatoryLicensedExtensions to check also transitive dependencies efficiently by remembering which dependencies were already verified
* cache the list of mandatory licensed extensions and invalidate it after each extension job
* update and add unit tests