### PR TITLE
New extension version available notification throws NPE on newer versions of XWiki #131

### DIFF
--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/resources/templates/newVersionAvailable.vm
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/resources/templates/newVersionAvailable.vm
@@ -34,14 +34,6 @@
 #end
 
 #define ($content)
-  #set ($document = $xwiki.getDocument($event.document))
-  <div class="notification-page">
-    ## Notifications are rendered in the context of their wiki, so we need to use the XWikiContext#originalWikiId
-    ## to actually know where the request comes from.
-    #if ($xcontext.getContext().getOriginalWikiId() != $event.document.wikiReference.name)
-      <span class="text-muted">($services.wiki.getById($event.document.wikiReference.name).prettyName)</span>
-    #end
-  </div>
   <div class="notification-description">
     <div class="activity-summary">
       #if ($event.events.size() == 1)


### PR DESCRIPTION
* remove unnecessary code, since the wiki name is already contained in each notification message

The error was caused by the fact that `$event.document` is no longer defined by default in newer versions of xwiki. In our case, this wasn't actually even needed since there's no associated document to the event and `$event.document.wikiReference.name` was always the same on older versions of xwiki