### PR TITLE
Rights error displayed for non-admin users in licensed applications #155

### DIFF
--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/VelocityMacros.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/VelocityMacros.xml
@@ -241,4 +241,87 @@
   &lt;/div&gt;
 #end
 {{/velocity}}</content>
+  <object>
+    <name>Licenses.Code.VelocityMacros</name>
+    <number>0</number>
+    <className>XWiki.XWikiRights</className>
+    <guid>d7630e8a-0068-4d2d-9bdb-eaed501b14b6</guid>
+    <class>
+      <name>XWiki.XWikiRights</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <allow>
+        <defaultValue>1</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>allow</displayType>
+        <name>allow</name>
+        <number>4</number>
+        <prettyName>Allow/Deny</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </allow>
+      <groups>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>groups</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Groups</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.GroupsClass</classType>
+      </groups>
+      <levels>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>1</multiSelect>
+        <name>levels</name>
+        <number>2</number>
+        <prettyName>Levels</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>3</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.LevelsClass</classType>
+      </levels>
+      <users>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <multiSelect>1</multiSelect>
+        <name>users</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Users</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
+      </users>
+    </class>
+    <property>
+      <allow>1</allow>
+    </property>
+    <property>
+      <groups>XWiki.XWikiAllGroup,</groups>
+    </property>
+    <property>
+      <levels>view</levels>
+    </property>
+    <property>
+      <users/>
+    </property>
+  </object>
 </xwikidoc>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/VelocityMacros.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/VelocityMacros.xml
@@ -321,7 +321,7 @@
       <levels>view</levels>
     </property>
     <property>
-      <users/>
+      <users>XWiki.XWikiGuest</users>
     </property>
   </object>
 </xwikidoc>


### PR DESCRIPTION
* give view rights on the VelocityMacros page for all users; this page is included in all licensed application since has macros for checking the license. E.g. for Diagram on [WebHome](https://github.com/xwikisas/application-diagram/blob/3a2858e097d76217d1c2f247b2efa9c0d31c4bd8/application-diagram-ui/src/main/resources/Diagram/WebHome.xml#L39) and [DiagramMacro](https://github.com/xwikisas/application-diagram/blob/3a2858e097d76217d1c2f247b2efa9c0d31c4bd8/application-diagram-ui/src/main/resources/Diagram/DiagramMacro.xml#L331)