### PR TITLE
legacy jquery "size()" replacted with "length"

### DIFF
--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebHome.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebHome.xml
@@ -617,7 +617,7 @@ require(['jquery', 'licensor', 'xwiki-meta', 'xwiki-l10n!auto-update-button', 'x
   // xwiki:livetable:displayComplete might be triggered before the code from this jsx is executed. In this case, the
   // livetable is also loaded before, because it is using Prototype.js which is loading before the page loads.
   // Make sure that the livetable is loaded by checking for a row with some data.
-  if ($('#licenseManager-display td.type').size() &gt; 0) {
+  if ($('#licenseManager-display td.type').length &gt; 0) {
     updateLivetableButtons();
   }
   $(document).on('xwiki:livetable:displayComplete', updateLivetableButtons);


### PR DESCRIPTION
jQuery has dropped the support for `size` method in v3.0 - it is replaced by `length` property.

Current version of XWiki uses jQuery v3.6.0 , which brakes the current implementation of this plugin.

See:
* https://api.jquery.com/size/