### PR TITLE
Upgrade licensor parent version to 14.10 #163

### DIFF
--- a/application-licensing-common/application-licensing-common-model/pom.xml
+++ b/application-licensing-common/application-licensing-common-model/pom.xml
@@ -39,35 +39,23 @@
     <!-- Only contain generated sources for which we don't control the code style -->
     <xwiki.checkstyle.skip>true</xwiki.checkstyle.skip>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
         <groupId>org.jvnet.jaxb2.maven2</groupId>
         <artifactId>maven-jaxb2-plugin</artifactId>
-        <version>0.12.3</version>
         <configuration>
-          <extension>true</extension>
-          <args>
-            <arg>-Xfluent-api</arg>
-          </args>
           <generatePackage>com.xwiki.licensing.model.jaxb</generatePackage>
-          <verbose>true</verbose>
-          <removeOldOutput>false</removeOldOutput>
-          <plugins>
-            <plugin>
-              <groupId>org.jvnet.jaxb2_commons</groupId>
-              <artifactId>jaxb2-fluent-api</artifactId>
-              <version>3.0</version>
-            </plugin>
-            <plugin>
-              <groupId>org.jvnet.jaxb2_commons</groupId>
-              <artifactId>jaxb2-default-value</artifactId>
-              <version>1.1</version>
-            </plugin>
-          </plugins>
         </configuration>
         <executions>
           <execution>
+            <id>generate</id>
             <goals>
               <goal>generate</goal>
             </goals>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/AddLicense.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/AddLicense.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.AddLicense" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.AddLicense" locale="">
   <web>Licenses.Code</web>
   <name>AddLicense</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/AutomaticUpgradesClass.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/AutomaticUpgradesClass.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.AutomaticUpgradesClass" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.AutomaticUpgradesClass" locale="">
   <web>Licenses.Code</web>
   <name>AutomaticUpgradesClass</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/AvailableTemplateProvidersFilter.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/AvailableTemplateProvidersFilter.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.AvailableTemplateProvidersFilter" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.AvailableTemplateProvidersFilter" locale="">
   <web>Licenses.Code</web>
   <name>AvailableTemplateProvidersFilter</name>
   <language/>
@@ -77,7 +77,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -97,6 +97,7 @@
         <name>content</name>
         <number>1</number>
         <prettyName>Executed Content</prettyName>
+        <restricted>0</restricted>
         <rows>25</rows>
         <size>120</size>
         <unmodifiable>0</unmodifiable>
@@ -127,6 +128,7 @@
         <name>parameters</name>
         <number>7</number>
         <prettyName>Extension Parameters</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/GetTrialLicenseService.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/GetTrialLicenseService.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.GetTrialLicenseService" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.GetTrialLicenseService" locale="">
   <web>Licenses.Code</web>
   <name>GetTrialLicenseService</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicenseJSON.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicenseJSON.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.LicenseJSON" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.LicenseJSON" locale="">
   <web>Licenses.Code</web>
   <name>LicenseJSON</name>
   <language/>
@@ -202,6 +202,7 @@ $jsontool.serialize({
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
+        <restricted>0</restricted>
         <rows>20</rows>
         <size>50</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensedExtensionUpgradeJob.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensedExtensionUpgradeJob.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.LicensedExtensionUpgradeJob" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.LicensedExtensionUpgradeJob" locale="">
   <web>Licenses.Code</web>
   <name>LicensedExtensionUpgradeJob</name>
   <language/>
@@ -101,6 +101,7 @@
         <name>jobDescription</name>
         <number>2</number>
         <prettyName>Job Description</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>45</size>
         <unmodifiable>0</unmodifiable>
@@ -122,6 +123,7 @@
         <name>script</name>
         <number>6</number>
         <prettyName>Job Script</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>60</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensesNotificationsUIX.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensesNotificationsUIX.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.LicensesNotificationsUIX" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.LicensesNotificationsUIX" locale="">
   <web>Licenses.Code</web>
   <name>LicensesNotificationsUIX</name>
   <language/>
@@ -115,6 +115,7 @@
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
+        <restricted>0</restricted>
         <rows>20</rows>
         <size>50</size>
         <unmodifiable>0</unmodifiable>
@@ -250,7 +251,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -270,6 +271,7 @@
         <name>content</name>
         <number>1</number>
         <prettyName>Executed Content</prettyName>
+        <restricted>0</restricted>
         <rows>25</rows>
         <size>120</size>
         <unmodifiable>0</unmodifiable>
@@ -300,6 +302,7 @@
         <name>parameters</name>
         <number>7</number>
         <prettyName>Extension Parameters</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingConfig.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingConfig.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.LicensingConfig" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.LicensingConfig" locale="">
   <web>Licenses.Code</web>
   <name>LicensingConfig</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingOwnerClass.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingOwnerClass.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.LicensingOwnerClass" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.LicensingOwnerClass" locale="">
   <web>Licenses.Code</web>
   <name>LicensingOwnerClass</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingStoreClass.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingStoreClass.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.LicensingStoreClass" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.LicensingStoreClass" locale="">
   <web>Licenses.Code</web>
   <name>LicensingStoreClass</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicenseMessageMacro.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicenseMessageMacro.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.MissingLicenseMessageMacro" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.MissingLicenseMessageMacro" locale="">
   <web>Licenses.Code</web>
   <name>MissingLicenseMessageMacro</name>
   <language/>
@@ -77,7 +77,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -97,6 +97,7 @@
         <name>code</name>
         <number>10</number>
         <prettyName>Macro code</prettyName>
+        <restricted>0</restricted>
         <rows>20</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -109,6 +110,7 @@
         <name>contentDescription</name>
         <number>9</number>
         <prettyName>Content description (Not applicable for "No content" type)</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -152,15 +154,24 @@
         <values>Optional|Mandatory|No content</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </contentType>
-      <defaultCategory>
+      <defaultCategories>
+        <cache>0</cache>
         <disabled>0</disabled>
-        <name>defaultCategory</name>
+        <displayType>input</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>defaultCategories</name>
         <number>4</number>
-        <prettyName>Default category</prettyName>
-        <size>30</size>
+        <prettyName>Default categories</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </defaultCategory>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </defaultCategories>
       <description>
         <contenttype>PureText</contenttype>
         <disabled>0</disabled>
@@ -168,6 +179,7 @@
         <name>description</name>
         <number>3</number>
         <prettyName>Macro description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -272,7 +284,7 @@
       <contentType>No content</contentType>
     </property>
     <property>
-      <defaultCategory/>
+      <defaultCategories/>
     </property>
     <property>
       <description>Display an error message when the extension does not have a valid license.</description>
@@ -321,6 +333,7 @@
         <name>description</name>
         <number>2</number>
         <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicensesUIX.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicensesUIX.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.MissingLicensesUIX" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.MissingLicensesUIX" locale="">
   <web>Licenses.Code</web>
   <name>MissingLicensesUIX</name>
   <language/>
@@ -77,7 +77,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -97,6 +97,7 @@
         <name>content</name>
         <number>1</number>
         <prettyName>Executed Content</prettyName>
+        <restricted>0</restricted>
         <rows>25</rows>
         <size>120</size>
         <unmodifiable>0</unmodifiable>
@@ -127,6 +128,7 @@
         <name>parameters</name>
         <number>7</number>
         <prettyName>Extension Parameters</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/NewExtensionVersionAvailableJob.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/NewExtensionVersionAvailableJob.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.NewExtensionVersionAvailableJob" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.NewExtensionVersionAvailableJob" locale="">
   <web>Licenses.Code</web>
   <name>NewExtensionVersionAvailableJob</name>
   <language/>
@@ -101,6 +101,7 @@
         <name>jobDescription</name>
         <number>2</number>
         <prettyName>Job Description</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>45</size>
         <unmodifiable>0</unmodifiable>
@@ -122,6 +123,7 @@
         <name>script</name>
         <number>6</number>
         <prettyName>Job Script</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>60</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/NewVersionNotificationClass.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/NewVersionNotificationClass.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.NewVersionNotificationClass" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.NewVersionNotificationClass" locale="">
   <web>Licenses.Code</web>
   <name>NewVersionNotificationClass</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/Translations.fr.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/Translations.fr.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.Translations" locale="fr">
+<xwikidoc version="1.5" reference="Licenses.Code.Translations" locale="fr">
   <web>Licenses.Code</web>
   <name>Translations</name>
   <language>fr</language>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/Translations.fr_FR.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/Translations.fr_FR.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.Translations" locale="fr_FR">
+<xwikidoc version="1.5" reference="Licenses.Code.Translations" locale="fr_FR">
   <web>Licenses.Code</web>
   <name>Translations</name>
   <language>fr_FR</language>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/Translations.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/Translations.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.Translations" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.Translations" locale="">
   <web>Licenses.Code</web>
   <name>Translations</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/UpdateAutomaticUpgradesAllowList.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/UpdateAutomaticUpgradesAllowList.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.UpdateAutomaticUpgradesAllowList" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.UpdateAutomaticUpgradesAllowList" locale="">
   <web>Licenses.Code</web>
   <name>UpdateAutomaticUpgradesAllowList</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/UpdateLicenses.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/UpdateLicenses.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.UpdateLicenses" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.UpdateLicenses" locale="">
   <web>Licenses.Code</web>
   <name>UpdateLicenses</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/UpdateOwnerDetails.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/UpdateOwnerDetails.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.UpdateOwnerDetails" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.UpdateOwnerDetails" locale="">
   <web>Licenses.Code</web>
   <name>UpdateOwnerDetails</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/VelocityMacros.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/VelocityMacros.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.VelocityMacros" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.VelocityMacros" locale="">
   <web>Licenses.Code</web>
   <name>VelocityMacros</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/WebHome.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/WebHome.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.Code.WebHome" locale="">
+<xwikidoc version="1.5" reference="Licenses.Code.WebHome" locale="">
   <web>Licenses.Code</web>
   <name>WebHome</name>
   <language/>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebHome.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebHome.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.WebHome" locale="">
+<xwikidoc version="1.5" reference="Licenses.WebHome" locale="">
   <web>Licenses</web>
   <name>WebHome</name>
   <language/>
@@ -409,6 +409,7 @@
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
+        <restricted>0</restricted>
         <rows>20</rows>
         <size>50</size>
         <unmodifiable>0</unmodifiable>
@@ -799,6 +800,7 @@ require(['jquery', 'licensor', 'xwiki-meta', 'xwiki-l10n!auto-update-button', 'x
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
+        <restricted>0</restricted>
         <rows>20</rows>
         <size>50</size>
         <unmodifiable>0</unmodifiable>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebPreferences.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebPreferences.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Licenses.WebPreferences" locale="">
+<xwikidoc version="1.5" reference="Licenses.WebPreferences" locale="">
   <web>Licenses</web>
   <name>WebPreferences</name>
   <language/>
@@ -288,6 +288,7 @@
         <number>26</number>
         <picker>0</picker>
         <prettyName>Confirmation eMail Content</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>72</size>
         <tooltip/>
@@ -512,6 +513,7 @@
         <number>27</number>
         <picker>0</picker>
         <prettyName>Invitation eMail Content</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>72</size>
         <tooltip/>
@@ -529,6 +531,7 @@
         <number>24</number>
         <picker>0</picker>
         <prettyName>Additional JavaMail properties</prettyName>
+        <restricted>0</restricted>
         <rows>6</rows>
         <size>60</size>
         <unmodifiable>0</unmodifiable>
@@ -635,6 +638,7 @@
         <number>60</number>
         <picker>0</picker>
         <prettyName>Ldap user fields mapping</prettyName>
+        <restricted>0</restricted>
         <rows>1</rows>
         <size>60</size>
         <unmodifiable>0</unmodifiable>
@@ -651,6 +655,7 @@
         <number>65</number>
         <picker>0</picker>
         <prettyName>Ldap groups mapping</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>60</size>
         <unmodifiable>0</unmodifiable>
@@ -856,6 +861,7 @@
         <number>16</number>
         <picker>0</picker>
         <prettyName>HTTP Meta Info</prettyName>
+        <restricted>0</restricted>
         <rows>8</rows>
         <size>60</size>
         <tooltip/>
@@ -1296,6 +1302,7 @@
         <number>25</number>
         <picker>0</picker>
         <prettyName>Validation eMail Content</prettyName>
+        <restricted>0</restricted>
         <rows>10</rows>
         <size>72</size>
         <tooltip/>
@@ -1351,7 +1358,19 @@
       <accessibility/>
     </property>
     <property>
+      <admin_email/>
+    </property>
+    <property>
       <colorTheme/>
+    </property>
+    <property>
+      <comment_anonymous/>
+    </property>
+    <property>
+      <comment_registered/>
+    </property>
+    <property>
+      <confirmation_email_content/>
     </property>
     <property>
       <core.defaultDocumentSyntax/>
@@ -1360,10 +1379,25 @@
       <dateformat/>
     </property>
     <property>
+      <default_language/>
+    </property>
+    <property>
+      <documentBundles/>
+    </property>
+    <property>
+      <edit_anonymous/>
+    </property>
+    <property>
+      <edit_registered/>
+    </property>
+    <property>
       <editcomment/>
     </property>
     <property>
       <editcomment_mandatory/>
+    </property>
+    <property>
+      <editor/>
     </property>
     <property>
       <guest_comment_requires_captcha/>
@@ -1372,7 +1406,13 @@
       <iconTheme/>
     </property>
     <property>
+      <invitation_email_content/>
+    </property>
+    <property>
       <javamail_extra_props/>
+    </property>
+    <property>
+      <languages/>
     </property>
     <property>
       <ldap/>
@@ -1432,7 +1472,13 @@
       <ldap_validate_password/>
     </property>
     <property>
+      <leftPanels/>
+    </property>
+    <property>
       <leftPanelsWidth/>
+    </property>
+    <property>
+      <meta/>
     </property>
     <property>
       <minoredit/>
@@ -1445,6 +1491,15 @@
     </property>
     <property>
       <plugins/>
+    </property>
+    <property>
+      <registration_anonymous/>
+    </property>
+    <property>
+      <registration_registered/>
+    </property>
+    <property>
+      <rightPanels/>
     </property>
     <property>
       <rightPanelsWidth/>
@@ -1465,7 +1520,13 @@
       <showinformation/>
     </property>
     <property>
+      <skin/>
+    </property>
+    <property>
       <smtp_port/>
+    </property>
+    <property>
+      <smtp_server/>
     </property>
     <property>
       <smtp_server_password/>
@@ -1474,13 +1535,31 @@
       <smtp_server_username/>
     </property>
     <property>
+      <stylesheet/>
+    </property>
+    <property>
+      <stylesheets/>
+    </property>
+    <property>
       <tags/>
     </property>
     <property>
       <timezone/>
     </property>
     <property>
+      <title/>
+    </property>
+    <property>
       <upload_maxsize/>
+    </property>
+    <property>
+      <validation_email_content/>
+    </property>
+    <property>
+      <version/>
+    </property>
+    <property>
+      <webcopyright/>
     </property>
     <property>
       <xwiki.title.mandatory/>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,9 @@
   <packaging>pom</packaging>
   <name>Licensing Application - Parent POM</name>
   <description>Application allowing the licensing of XWiki extensions</description>
+  <properties>
+    <xwiki.enforcer.banneddependencytype-xar.skip>true</xwiki.enforcer.banneddependencytype-xar.skip>
+  </properties>
   <scm>
     <connection>scm:git:git://github.com/xwikisas/application-licensing.git</connection>
     <developerConnection>scm:git:git@github.com:xwikisas/application-licensing.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.parent</groupId>
     <artifactId>xwikisas-parent-platform</artifactId>
-    <version>13.10-3</version>
+    <version>14.10-1</version>
   </parent>
   <groupId>com.xwiki.licensing</groupId>
   <artifactId>application-licensing</artifactId>


### PR DESCRIPTION
* update parent version
* export from 14.10 and remove deprecated property defaultCategory
* update jaxb plugin configuration, which was duplicated from the parent version
* add a dependency needed by jaxb
* skip banned depedency type enforcer