### PR TITLE
Update check modifies cached document instance #185

### DIFF
--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/upgrades/NewVersionNotificationManager.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/upgrades/NewVersionNotificationManager.java
@@ -106,7 +106,7 @@ public class NewVersionNotificationManager
     {
         try {
             XWikiContext xcontext = contextProvider.get();
-            XWikiDocument configDoc = xcontext.getWiki().getDocument(LICENSING_CONFIG_DOC, xcontext);
+            XWikiDocument configDoc = xcontext.getWiki().getDocument(LICENSING_CONFIG_DOC, xcontext).clone();
             List<BaseObject> versionNotifObjects = configDoc.getXObjects(NEW_VERSION_NOTIFICATION_CLASS);
 
             boolean notificationObjectExists = false;

--- a/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/upgrades/NewVersionNotificationManagerTest.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/upgrades/NewVersionNotificationManagerTest.java
@@ -132,7 +132,7 @@ class NewVersionNotificationManagerTest
             xcontext)).thenReturn(0);
         when(this.licensingDoc.getXObject(NewVersionNotificationManager.NEW_VERSION_NOTIFICATION_CLASS, 0)).thenReturn(
             this.newVersionObject1);
-
+        when(this.licensingDoc.clone()).thenReturn(licensingDoc);
         this.newVersionNotificationManager.markNotificationAsSent("extension1", "root", "2.1");
 
         verify(this.newVersionObject1, times(1)).setStringValue(NewVersionNotificationManager.EXTENSION_ID,
@@ -152,6 +152,7 @@ class NewVersionNotificationManagerTest
         when(newVersionObject1.getStringValue(NewVersionNotificationManager.EXTENSION_ID)).thenReturn("extension1");
         when(newVersionObject1.getStringValue(NewVersionNotificationManager.NAMESPACE)).thenReturn("root");
         when(newVersionObject1.getStringValue(NewVersionNotificationManager.VERSION)).thenReturn("1.0");
+        when(this.licensingDoc.clone()).thenReturn(licensingDoc);
 
         this.newVersionNotificationManager.markNotificationAsSent("extension1", "root", "1.1");
 
@@ -169,6 +170,7 @@ class NewVersionNotificationManagerTest
         when(newVersionObject1.getStringValue(NewVersionNotificationManager.EXTENSION_ID)).thenReturn("extension1");
         when(newVersionObject1.getStringValue(NewVersionNotificationManager.NAMESPACE)).thenReturn("root");
         when(newVersionObject1.getStringValue(NewVersionNotificationManager.VERSION)).thenReturn("1.0");
+        when(this.licensingDoc.clone()).thenReturn(licensingDoc);
 
         when(this.licensingDoc.createXObject(NewVersionNotificationManager.NEW_VERSION_NOTIFICATION_CLASS,
             xcontext)).thenReturn(1);


### PR DESCRIPTION
I couldn’t really reproduce the issue, even after waiting for 20 minutes. But taking into account the information from here: https://www.xwiki.org/xwiki/bin/view/ReleaseNotes/Data/XWiki/17.2.0RC1#HProtectionagainstconcurrentmodificationofcacheddocument, the issue is caused by updating a document that was retrieved from the cache. I just took a look at all the places where a document was retrieved and updated the code to use a clone of the document wherever it was being modified.