### PR TITLE
Upgrade XWiki parent to 15.10 #223

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage and enforce application licenses for paid extensions
 * [Documentation & Download](http://store.xwiki.com/xwiki/bin/view/Extension/Licensing+Application)
 * [JIRA Issue Tracker](https://github.com/xwikisas/application-licensing/issues)
 * [Development Practices](http://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices)
-* Minimal XWiki version supported: XWiki 14.10
+* Minimal XWiki version supported: XWiki 15.10
 * License: LGPL 2.1
 * Translations: N/A 
 * Sonar Dashboard: N/A 

--- a/application-licensing-common/application-licensing-common-api/src/main/java/com/xwiki/licensing/License.java
+++ b/application-licensing-common/application-licensing-common-api/src/main/java/com/xwiki/licensing/License.java
@@ -402,7 +402,7 @@ public class License implements Comparable<License>
         return getId().compareTo(getId());
     }
 
-    private static class CollectionEqualsBuilder extends EqualsBuilder
+    private static final class CollectionEqualsBuilder extends EqualsBuilder
     {
         @Override
         public EqualsBuilder append(Object lhs, Object rhs)

--- a/application-licensing-common/application-licensing-common-model/pom.xml
+++ b/application-licensing-common/application-licensing-common-model/pom.xml
@@ -48,14 +48,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
+        <groupId>org.jvnet.jaxb</groupId>
+        <artifactId>jaxb-maven-plugin</artifactId>
         <configuration>
           <generatePackage>com.xwiki.licensing.model.jaxb</generatePackage>
         </configuration>
         <executions>
           <execution>
-            <id>generate</id>
             <goals>
               <goal>generate</goal>
             </goals>

--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/DefaultLicenseManager.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/DefaultLicenseManager.java
@@ -66,7 +66,7 @@ import com.xwiki.licensing.internal.enforcer.LicensingUtils;
 @Singleton
 public class DefaultLicenseManager implements LicenseManager, Initializable
 {
-    private class LinkLicenseToInstalledExtensionsRunnable implements Runnable
+    private final class LinkLicenseToInstalledExtensionsRunnable implements Runnable
     {
         @Override
         public void run()

--- a/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/LicenseRenewListenerTest.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/test/java/com/xwiki/licensing/internal/LicenseRenewListenerTest.java
@@ -127,7 +127,6 @@ public class LicenseRenewListenerTest
 
         verify(licenseUpdater).updateLicenses();
         verify(licenseUpdater).renewLicense(extensionId);
-        verify(license, never()).getFeatureIds();
     }
 
     @Test

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensesNotificationsUIX.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensesNotificationsUIX.xml
@@ -389,7 +389,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingConfig.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/LicensingConfig.xml
@@ -142,7 +142,6 @@
       <email>
         <customDisplay/>
         <disabled>0</disabled>
-        <hint/>
         <name>email</name>
         <number>3</number>
         <picker>0</picker>
@@ -156,7 +155,6 @@
       <firstName>
         <customDisplay/>
         <disabled>0</disabled>
-        <hint/>
         <name>firstName</name>
         <number>1</number>
         <picker>0</picker>
@@ -170,7 +168,6 @@
       <lastName>
         <customDisplay/>
         <disabled>0</disabled>
-        <hint/>
         <name>lastName</name>
         <number>2</number>
         <picker>0</picker>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicenseMessageMacro.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicenseMessageMacro.xml
@@ -77,7 +77,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -361,13 +361,24 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
       <type>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
         <name>type</name>
         <number>5</number>
+        <picker>1</picker>
         <prettyName>Parameter type</prettyName>
-        <size>60</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </type>
     </class>
     <property>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicensesUIX.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/Code/MissingLicensesUIX.xml
@@ -77,7 +77,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebPreferences.xml
+++ b/application-licensing-licensor/application-licensing-licensor-ui/src/main/resources/Licenses/WebPreferences.xml
@@ -304,7 +304,7 @@
   #set ($value = $xwiki.getDefaultDocumentSyntax())
 #end
 &lt;select name="${object.getxWikiClass().name}_${object.number}_${name}" id="${object.getxWikiClass().name}_${object.number}_${name}"&gt;
-#set ($configuredSyntaxes = $services.rendering.getConfiguredSyntaxes())
+#set ($configuredSyntaxes = $collectiontool.sort($services.rendering.getConfiguredSyntaxes()))
 #foreach($syntax in $configuredSyntaxes)
   &lt;option value="$syntax.toIdString()"#if($syntax.toIdString().equalsIgnoreCase($value)) selected="selected"#end&gt;$syntax.toString()&lt;/option&gt;
 #end
@@ -744,7 +744,7 @@
         <name>ldap_server</name>
         <number>51</number>
         <picker>0</picker>
-        <prettyName>Ldap server address</prettyName>
+        <prettyName>Ldap server adress</prettyName>
         <size>60</size>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>

--- a/application-licensing-test/application-licensing-test-docker/src/test/it/com/xwiki/licensing/test/ui/AllIT.java
+++ b/application-licensing-test/application-licensing-test-docker/src/test/it/com/xwiki/licensing/test/ui/AllIT.java
@@ -42,28 +42,28 @@ import org.xwiki.test.docker.junit5.UITest;
     },
     extraJARs = {
         // Required for the instance.hbm.xml file.
-        "org.xwiki.platform:xwiki-platform-instance:14.10",
-        "org.xwiki.platform:xwiki-platform-eventstream-api:14.10",
-        "org.xwiki.platform:xwiki-platform-eventstream-store-solr:14.10",
+        "org.xwiki.platform:xwiki-platform-instance:15.10",
+        "org.xwiki.platform:xwiki-platform-eventstream-api:15.10",
+        "org.xwiki.platform:xwiki-platform-eventstream-store-solr:15.10",
 
         // Required for the notification-filter-preferences.hbm.xml file.
-        "org.xwiki.platform:xwiki-platform-notifications-filters-default:14.10",
+        "org.xwiki.platform:xwiki-platform-notifications-filters-default:15.10",
 
         // The component manager fails to load WikiMacroEventListener when wikimacro-api and wikimacro-store are
         // installed at runtime. We force them as core extensions.
-        "org.xwiki.platform:xwiki-platform-rendering-wikimacro-store:14.10",
+        "org.xwiki.platform:xwiki-platform-rendering-wikimacro-store:15.10",
 
         // Required by the Crypto Store script service, which is a core extension and injects the filesystem and wiki
         // implementations directly (so the root component manager is used).
-        "org.xwiki.commons:xwiki-commons-crypto-store-filesystem:14.10",
-        "org.xwiki.platform:xwiki-platform-crypto-store-wiki:14.10",
+        "org.xwiki.commons:xwiki-commons-crypto-store-filesystem:15.10",
+        "org.xwiki.platform:xwiki-platform-crypto-store-wiki:15.10",
 
         // The JodaTime plugin needs to be in WEB-INF/lib since it's defined in xwiki.cfg and plugins are loaded by
         // XWiki at startup, i.e. before extensions are provisioned for the tests.
-        "org.xwiki.platform:xwiki-platform-jodatime:14.10"
+        "org.xwiki.platform:xwiki-platform-jodatime:15.10"
     } , resolveExtraJARs = true
 )
-class AllITs
+class AllIT
 {
     @Nested
     @DisplayName("Overall Licensing UI")

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.parent</groupId>
     <artifactId>xwikisas-parent-platform</artifactId>
-    <version>14.10-1</version>
+    <version>15.10</version>
   </parent>
   <groupId>com.xwiki.licensing</groupId>
   <artifactId>application-licensing</artifactId>


### PR DESCRIPTION
* upgrade parent in pom -> ~I would still release a new xwikisas parent in order to use the latest parent version from contrib~ -> 15.10 is ok, the new ones use 15.10.15 https://github.com/xwiki-contrib/parent/blob/parent-15.10/parent-platform/pom.xml
* fix checkstyle since some classes weren't marked as final
* use the correct jaxb plugin -> jaxb2 usage was removed in 15.10rc1
* fix failing test -> that check was added in order to check the execution doesn't reach a certain place, but it was actually used already in another License.equals calls (not sure why it didn't failed before)
* update test class to use 15.10 for extraJars + use AllIT name instead of AllITs - this was changed around 15.5 in XS
* update readme
* apply xar:format for licensor pages
* tested store and licensor part