### PR TITLE
Extension auto upgrade job does not send a notification #225

### DIFF
--- a/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/upgrades/UpgradeExtensionHandler.java
+++ b/application-licensing-licensor/application-licensing-licensor-api/src/main/java/com/xwiki/licensing/internal/upgrades/UpgradeExtensionHandler.java
@@ -117,12 +117,14 @@ public class UpgradeExtensionHandler
         for (Version version : versions) {
             ExtensionId toInstallExtensionId = new ExtensionId(installedExtensionId.getId(), version);
             try {
+                // We get the configured groups before the installation extension job, as the cache is reset during the
+                // job and the configuration is no longer available.
+                Set<String> notifiedGroups = getTargetGroups();
                 installExtension(toInstallExtensionId, namespace);
 
                 String doneUpgradeMessage = this.localization.getTranslationPlain(
                     "licensor.notification.autoUpgrade.done", installedExtension.getName(),
                     installedExtensionId.getVersion().getValue(), toInstallExtensionId.getVersion().getValue());
-                Set<String> notifiedGroups = getTargetGroups();
                 this.observationManager.notify(new ExtensionAutoUpgradedEvent(notifiedGroups), LICENSOR_API_ID,
                     doneUpgradeMessage);
 


### PR DESCRIPTION
Moved configurtion call before extension installation job to avoid errors due to cache reset.